### PR TITLE
Remove contrapath and allow filtering based on path and msg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 0.4
+
+* BREAKING CHANGE: Remove `contrapath`. This was necessary to allow filtering based on path.
+
+* BREAKING CHANGE: Add path and msg as arguments to filter function.
+
 # Version 0.3
 
 * BREAKING CHANGE: `mkDiTextStderr` and `mkDiStringHandle` return a `Di String

--- a/di.cabal
+++ b/di.cabal
@@ -1,5 +1,5 @@
 name: di
-version: 0.3
+version: 0.4
 author: Renzo Carbonara
 maintainer: renλren.zone
 copyright: Renzo Carbonara 2017-2018

--- a/src/Di.hs
+++ b/src/Di.hs
@@ -17,7 +17,6 @@ module Di
  , push
  , filter
  , contralevel
- , contrapath
  , contramsg
    -- * Backends
  , mkDi
@@ -28,7 +27,7 @@ module Di
 import Prelude hiding (filter, log)
 
 import Di.Core
-  (Di, log, flush, push, filter, contralevel, contrapath, contramsg, mkDi)
+  (Di, log, flush, push, filter, contralevel, contramsg, mkDi)
 import qualified Di.Backend as B
 
 

--- a/src/Di/Backend.hs
+++ b/src/Di/Backend.hs
@@ -13,7 +13,7 @@ import Prelude hiding (log, filter)
 import qualified System.IO as IO
 import Data.Semigroup (Semigroup(..))
 
-import Di.Core (Di, mkDi, contrapath)
+import Di.Core (Di, mkDi)
 
 --------------------------------------------------------------------------------
 
@@ -70,13 +70,12 @@ mkDiStringHandle
   -> m (Di String [String] String)
 mkDiStringHandle h = liftIO $ do
     IO.hSetBuffering h IO.LineBuffering
-    fmap (contrapath (mconcat . map stringPathSingleton)) $ do
-       mkDi $ \ts l p m -> do
-          IO.hPutStrLn h $ mconcat
-             [ l, " ", renderIso8601 ts
-             , if p == mempty then "" else (" " <> unStringPath p)
-             , ": ", noBreaks m ]
-          IO.hFlush h
+    mkDi $ \ts l p m -> do
+      IO.hPutStrLn h $ mconcat
+        [ l, " ", renderIso8601 ts
+        , if p == mempty then "" else (" " <> unStringPath (foldMap stringPathSingleton p))
+        , ": ", noBreaks m ]
+      IO.hFlush h
   where
     noBreaks :: String -> String
     noBreaks = concatMap $ \case


### PR DESCRIPTION
This fixes #4 and is related to #18. 

I did need to remove `contrapath` to get this to work since `path` is now used in negative and positive positions. However, since you seemed to be okay with restricting the path even further as described in #18, I don’t think this is a problem (personally I wouldn’t restrict it to `[Text]` but I’m not strongly opposed to that either).

You can technically get a version of `contrapath` to typecheck and avoid explicitely storing the path but that leads to `filter` and `push` not commuting, i.e., `filter . push` will filter based on the original path whereas `push . filter` will filter based on the updated path. At least to me that seems like very confusing behavior.

This PR generalizes `filter` to also take the `msg` as an argument since that’s trivial to do and seems like something one might want to do.