### PR TITLE
df1: do not preprocess Key, Value and Message text

### DIFF
--- a/df1/lib/Df1/Types.hs
+++ b/df1/lib/Df1/Types.hs
@@ -61,7 +61,7 @@ newtype Message = Message TL.Text
   deriving (Eq, Show)
 
 message :: TL.Text -> Message
-message = Message . TL.dropAround (== ' ')
+message = Message
 {-# INLINE message #-}
 
 unMessage :: Message -> TL.Text
@@ -179,7 +179,7 @@ newtype Key = Key T.Text
   deriving (Eq, Show)
 
 key :: T.Text -> Key
-key = Key . T.dropAround (== ' ')
+key = Key
 {-# INLINE key #-}
 
 unKey :: Key -> T.Text
@@ -227,7 +227,7 @@ unValue = \(Value x) -> x
 {-# INLINE unValue #-}
 
 value :: TL.Text -> Value
-value = Value . TL.dropAround (== ' ')
+value = Value
 {-# INLINE value #-}
 
 instance IsString Value where

--- a/df1/lib/Df1/Types.hs
+++ b/df1/lib/Df1/Types.hs
@@ -50,13 +50,6 @@ data Log = Log
 -- @
 -- \"foo\" :: 'Message'
 -- @
---
--- Please keep in mind that 'Message' will always strip surrounding whitespace.
--- That is:
---
--- @
--- \"x\" :: 'Message'  ==  \" x\"  == \"x \" == \" x \"
--- @
 newtype Message = Message TL.Text
   deriving (Eq, Show)
 
@@ -168,13 +161,6 @@ instance Monoid Segment where
 -- @
 --
 -- Otherwise, you can use 'fromString' or the 'key' function.
---
--- Please keep in mind that 'Key' will always strip surrounding whitespace.
--- That is:
---
--- @
--- \"x\" :: 'Key'  ==  \" x\"  == \"x \" == \" x \"
--- @
 newtype Key = Key T.Text
   deriving (Eq, Show)
 
@@ -212,13 +198,6 @@ instance Monoid Key where
 -- @
 --
 -- Otherwise, you can use 'fromString' or the 'value' function.
---
--- Please keep in mind that 'value' will always strip surrounding whitespace.
--- That is:
---
--- @
--- \"x\" :: 'Value'  ==  \" x\"  == \"x \" == \" x \"
--- @
 newtype Value = Value TL.Text
   deriving (Eq, Show)
 


### PR DESCRIPTION
Fixes #38 

Note: `Key`, `Value` and `Message` are newtypes so I am not sure it's worth inlining the (smart) constructors. I see you inlined the accessors as well so there's probably a reason.